### PR TITLE
Clearly separate responsibilities between FAQ and Troubleshooting.

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -6,6 +6,10 @@ nav_order: 10
 # Frequently Asked Questions
 {: .no_toc }
 
+General questions and further learnings regarding the technology used in Umbrel.
+
+Issues concerning the primary operations of your Umbrel node can be found in the separate [Troubleshooting](troubleshooting.md) guide.
+
 ## Table of contents
 {: .no_toc .text-delta }
 
@@ -13,92 +17,52 @@ nav_order: 10
 {:toc}
 
 ## Can I get rich by routing Lightning payments?
+
 Nobody knows. Probably not. You will get minimal fees. I don't care. Enjoy the ride!
 
 ## Can I attach the Ext4 formatted hard disk to my Windows computer?
-The Ext4 file system is not compatible with standard Windows, but with additional software like  [Linux File Systems](https://www.paragon-software.com/home/linuxfs-windows/#faq) by Paragon Software (they offer a 10 days free trial) it is possible.
+
+The Ext4 file system is not compatible with standard Windows, but with additional software like [Linux File Systems](https://www.paragon-software.com/home/linuxfs-windows/#faq) by Paragon Software (they offer a 10 days free trial) it is possible.
 
 ## What do all the Linux commands do?
+
 This is a (very) short list of common Linux commands for your reference. For a specific command, you can enter `man [command]` to display the manual page (type `q` to exit).
 
-| command | description | example |
-| -- | -- | -- |
-| `cd` | change to directory | `cd /home/umbrel` |
-| `ls` | list directory content | `ls -la /home/umbrel/umbrel` |
-| `cp` | copy | `cp file.txt newfile.txt` |
-| `mv` | move | `mv file.txt moved_file.txt`
-| `rm` | remove | `rm temporaryfile.txt`
-| `mkdir` | make directory | `mkdir /home/umbrel/newdirectory`
-| `ln` | make link | `ln -s /target_directory /link`
-| `sudo` | run command as superuser | `sudo nano textfile.txt`
-| `su` | switch to different user account | `sudo su root`
-| `chown` | change file owner  | `chown umbrel:umbrel myfile.txt`
-| `chmod` | change file permissions | `chmod +x executable.script`
-| `nano` | text file editor | `nano textfile.txt`
-| `tar` | archive tool | `tar -cvf archive.tar file1.txt file2.txt`
-| `exit` | exit current user session | `exit`
-| `systemctl` | control systemd service | `sudo systemctl start umbrel-startup`
-| `journalctl` | query systemd journal | `sudo journalctl -u umbrel-external-storage`
-| `htop` | monitor processes & resource usage | `htop`
-| `shutdown` | shutdown or restart Pi | `sudo shutdown -r now`
-
+| command      | description                        | example                                      |
+| ------------ | ---------------------------------- | -------------------------------------------- |
+| `cd`         | change to directory                | `cd /home/umbrel`                            |
+| `ls`         | list directory content             | `ls -la /home/umbrel/umbrel`                 |
+| `cp`         | copy                               | `cp file.txt newfile.txt`                    |
+| `mv`         | move                               | `mv file.txt moved_file.txt`                 |
+| `rm`         | remove                             | `rm temporaryfile.txt`                       |
+| `mkdir`      | make directory                     | `mkdir /home/umbrel/newdirectory`            |
+| `ln`         | make link                          | `ln -s /target_directory /link`              |
+| `sudo`       | run command as superuser           | `sudo nano textfile.txt`                     |
+| `su`         | switch to different user account   | `sudo su root`                               |
+| `chown`      | change file owner                  | `chown umbrel:umbrel myfile.txt`             |
+| `chmod`      | change file permissions            | `chmod +x executable.script`                 |
+| `nano`       | text file editor                   | `nano textfile.txt`                          |
+| `tar`        | archive tool                       | `tar -cvf archive.tar file1.txt file2.txt`   |
+| `exit`       | exit current user session          | `exit`                                       |
+| `systemctl`  | control systemd service            | `sudo systemctl start umbrel-startup`        |
+| `journalctl` | query systemd journal              | `sudo journalctl -u umbrel-external-storage` |
+| `htop`       | monitor processes & resource usage | `htop`                                       |
+| `shutdown`   | shutdown or restart Pi             | `sudo shutdown -r now`                       |
 
 ## Where can I get more information?
+
 If you want to learn more about Bitcoin and are curious about the inner workings of the Lightning Network, the following articles in Bitcoin Magazine offer a very good introduction:
 
-* [What is Bitcoin?](https://bitcoinmagazine.com/guides/what-bitcoin)
-* [Understanding the Lightning Network](https://bitcoinmagazine.com/articles/understanding-the-lightning-network-part-building-a-bidirectional-payment-channel-1464710791/)
-* [Bitcoin resources](https://www.lopp.net/bitcoin-information.html) and [Lightning Network resources](https://www.lopp.net/lightning-information.html) by Jameson Lopp
-
-## Setting a fixed address on the Raspberry Pi
-If your router does not support setting a static ip address for a single device, you can also do this directly on the Raspberry Pi.
-
-This can be done by configuring the DHCP-Client (on the Pi) to advertise a static IP address to the DHCP-Server (often the router) before it automatically assigns a different one to the Raspberry Pi.
-
-1. Get ip address of default gateway (router).
-   Run `netstat -r -n` and choose the IP address from the gateway column which is not `0.0.0.0`. In my occasion it's `192.168.178.1`.
-
-2. Configure the static IP address for the Pi, the gateway path and a DNS server.
-   The configuration for the DHCP client (Pi) is located in the `/etc/dhcpcd.conf` file:
-   ```
-   sudo nano /etc/dhcpcd.conf
-   ```
-   The following snippet is an example of a sample configuration. Change the value of `static routers` and `static domain_name_servers` to the IP of your router (default gateway) from step 1. Be aware of giving the Raspberry Pi an address which is **OUTSIDE** the range of addresses which are assigned by the DHCP server. You can get this range by looking under the router configurations page and checking for the range of the DHCP addresses. This means, that if the DHCP range goes from `192.168.178.1` to `192.168.2.99` you're good to go with the IP `192.168.178.100` for your Raspberry Pi.
-
-   Add the following to the `/etc/dhcpcd.conf` file:
-   ```
-   # Configuration static IP address (CHANGE THE VALUES TO FIT FOR YOUR NETWORK)
-   interface eth0
-   static ip_address=192.168.178.100/24
-   static routers=192.168.178.1
-   static domain_name_servers=192.168.178.1
-   ```
-
-3. Restart networking system
-  `sudo /etc/init.d/networking restart`
-
+- [What is Bitcoin?](https://bitcoinmagazine.com/guides/what-bitcoin)
+- [Understanding the Lightning Network](https://bitcoinmagazine.com/articles/understanding-the-lightning-network-part-building-a-bidirectional-payment-channel-1464710791/)
+- [Bitcoin resources](https://www.lopp.net/bitcoin-information.html) and [Lightning Network resources](https://www.lopp.net/lightning-information.html) by Jameson Lopp
 
 ## Does Umbrel support .....?
-Currently not, but the we are working on an application infrastructure, so third-party developers can add their own apps to Umbrel.
 
+Currently not, but the we are working on an application infrastructure, so third-party developers can add their own apps to Umbrel and publish them in its [App Store](https://medium.com/getumbrel/introducing-the-umbrel-app-store-7a2068c64a10).
 
-## How can I use WiFi instead of Ethernet?
+---
 
+This General FAQ guide will be constantly updated with findings that have been or will be reported in the issues section. Feel free to contribute via a pull request.
 
-* Create a file `wpa_supplicant.conf` in the boot partition of the microSD card with the following content.
-  Note that the network name (ssid) and password need to be in double-quotes (like `psk="password"`)
-
-  ```conf
-  ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
-  update_config=1
-  country=[COUNTRY_CODE]
-  network={
-    ssid="[WIFI_SSID]"
-    psk="[WIFI_PASSWORD]"
-  }
-  ```
-
-* Replace `[COUNTRY_CODE]` with the [ISO2 code](https://www.iso.org/obp/ui/#search){:target="_blank"} of your country (eg. `US`)
-* Replace `[WIFI_SSID]` and `[WIFI_PASSWORD]` with the credentials for your own WiFi.
-
-------
+---

--- a/index.md
+++ b/index.md
@@ -19,6 +19,7 @@ This page is intended to answer your questions about Umbrel.
 ---
 
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
@@ -31,11 +32,14 @@ This page is intended to answer your questions about Umbrel.
 ### Structure
 
 1. Introduction (this page)
-1. [FAQ](faq.md): frequently asked questions and further reading
-1. [Troubleshooting](troubleshooting.md): debug your system if you have problems
+2. [Troubleshooting](troubleshooting.md): Issues concerning the primary operations of your Umbrel node.
+3. [General FAQ](faq.md): General questions and further learnings regarding the technology used in Umbrel.
+
+---
 
 ## A word of caution
+
 Umbrel I still in beta and should not be considered secure.
 We do not recommend running it with much money yet.
 
------
+---

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -3,28 +3,25 @@ layout: default
 title: Troubleshooting
 nav_order: 20
 ---
+
 # Troubleshooting
+
 {: .no_toc }
 
+Issues concerning the primary operations of your Umbrel node.
+
+The aim of this troubleshooting guide is to help debug your system, verify all important configuration and diagnose problems that keep you from running the perfect node. Where possible, relevant parts of the guide will be linked.
+
+If you see any discrepancies from the expected output, double check how you set up your node in that specific area.
+
+General questions and further learnings regarding the technology used in Umbrel can be found in the separate [General FAQ](faq.md).
+
 ## Table of contents
+
 {: .no_toc .text-delta }
 
 1. TOC
-{:toc}
-
-The aim of this additional troubleshooting guide is to help you debug your system, verify all important configurations and find the frikkin' little problem that keeps you from running the perfect Lightning node.
-
-Where possible, I'll link to the relevant part of the guide. If you see any discrepancies from the expected output, double check how you set up your node in that specific area.
-
-### [General FAQ](faq.md)
-
-You can find frequent questions not directly related with issues in a separate [General FAQ](faq.md) section:
-
-* Can I get rich by routing Lightning payments?
-* Can I attach the Ext4 formatted hard disk to my Windows computer?
-* What do all the Linux commands do?
-* Where can I get more information?
-
+   {:toc}
 
 ### Common problems
 
@@ -37,19 +34,21 @@ Yes! The username is `umbrel`, the password is `moneyprintergobrrr`.
 If you have a Raspberry Pi with at least 4GB of RAM, you can run Umbrel on it.
 
 #### My Umbrel node keeps crashing. What can I do to fix the issue?
+
 If you're not using the official power supply, it's probably the power supply.
 To detect undervoltage, connect to your node via SSH and run this command: `vcgencmd get_throttled`.
 If it doesn't output throttled=0x0, then it's either the power supply or your SSD is using too much power (this can only be the case if you're not using the recommended hardware).
 
 #### My Umbrel node doesn't boot. What can I do?
+
 Do you have connected anything to the GPIO pins?
 If yes, try to unplug it and reboot the RPi by unplugging the power supply and then plugging it back in.
 
 #### I can't access the dashboard at umbrel.local. What can I do?
+
 Check if your router detects your node.
 If it doesn't, either you ethernet cable isn't plugged in correctly or the node doesn't boot.
 If you think the ethernet cable isn't the issue, follow the answer of the previous question.
-
 
 If it does detect the node, try to access it with the IP address directly.
 If you can't access the dashboard via the IP address either,
@@ -61,10 +60,60 @@ If the output doesn't contain this text, run `sudo systemctl start umbrel-startu
 You should now be able to access the dashboard.
 
 #### I want to connect to my node using ...... over my local network, but it doesn't work. How can I fix this?
+
 If you want to connect to your Umbrel over the local network just replace your onion domain with umbrel.local for any of the connection strings.
 
------
+#### Setting a fixed address on the Raspberry Pi
 
-I will extend this troubleshooting guide constantly with findings that have been or will be reported in the issues section.
+If your router does not support setting a static ip address for a single device, you can also do this directly on the Raspberry Pi.
 
------
+This can be done by configuring the DHCP-Client (on the Pi) to advertise a static IP address to the DHCP-Server (often the router) before it automatically assigns a different one to the Raspberry Pi.
+
+1. Get ip address of default gateway (router).
+   Run `netstat -r -n` and choose the IP address from the gateway column which is not `0.0.0.0`. In my occasion it's `192.168.178.1`.
+
+2. Configure the static IP address for the Pi, the gateway path and a DNS server.
+   The configuration for the DHCP client (Pi) is located in the `/etc/dhcpcd.conf` file:
+
+   ```
+   sudo nano /etc/dhcpcd.conf
+   ```
+
+   The following snippet is an example of a sample configuration. Change the value of `static routers` and `static domain_name_servers` to the IP of your router (default gateway) from step 1. Be aware of giving the Raspberry Pi an address which is **OUTSIDE** the range of addresses which are assigned by the DHCP server. You can get this range by looking under the router configurations page and checking for the range of the DHCP addresses. This means, that if the DHCP range goes from `192.168.178.1` to `192.168.2.99` you're good to go with the IP `192.168.178.100` for your Raspberry Pi.
+
+   Add the following to the `/etc/dhcpcd.conf` file:
+
+   ```
+   # Configuration static IP address (CHANGE THE VALUES TO FIT FOR YOUR NETWORK)
+   interface eth0
+   static ip_address=192.168.178.100/24
+   static routers=192.168.178.1
+   static domain_name_servers=192.168.178.1
+   ```
+
+3. Restart networking system
+   `sudo /etc/init.d/networking restart`
+
+#### Using WiFi instead of Ethernet
+
+- Create a file `wpa_supplicant.conf` in the boot partition of the microSD card with the following content.
+  Note that the network name (ssid) and password need to be in double-quotes (like `psk="password"`)
+
+  ```conf
+  ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+  update_config=1
+  country=[COUNTRY_CODE]
+  network={
+    ssid="[WIFI_SSID]"
+    psk="[WIFI_PASSWORD]"
+  }
+  ```
+
+- Replace `[COUNTRY_CODE]` with the [ISO2 code](https://www.iso.org/obp/ui/#search){:target="\_blank"} of your country (eg. `US`)
+- Replace `[WIFI_SSID]` and `[WIFI_PASSWORD]` with the credentials for your own WiFi.
+
+---
+
+This troubleshooting guide will be constantly updated with findings that have been or will be reported in the issues section. Feel free to contribute via a pull request.
+
+---


### PR DESCRIPTION
1️⃣ The goal of this PR is to make it 100% clear which question belongs in which of the two sections:

**Troubleshooting:** Issues concerning the primary operations of your Umbrel node.
**General FAQ:** General questions and further learnings regarding the technology used in Umbrel.

Using that same description in 3 places now:

1. Index file
2. Top of the file to describe itself
3. When linking to the related section (e.g. linking from FAQ to Troubleshooting)

2️⃣ I moved the following paragraphs from FAQ to Troubleshooting with the reason that they are pertinent to running the Umbrel node:

1. Setting a fixed address on the Raspberry Pi
2. How can I use WiFi instead of Ethernet?

3️⃣ Additionally there are some slight wording changes where I felt like it could read better (maybe more subjective, but I hope it's okay).

4️⃣ Finally some small formatting updates like to the linux command table that my prettier formatters automatically did on save that I thought was not worth to undo.