### PR TITLE
Fix TOS

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -14,7 +14,7 @@ Issues concerning the primary operations of your Umbrel node can be found in the
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
+{:toc}
 
 ### Can I get rich by routing Lightning payments?
 

--- a/index.md
+++ b/index.md
@@ -19,7 +19,6 @@ This page is intended to answer your questions about Umbrel.
 ---
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -5,7 +5,6 @@ nav_order: 10
 ---
 
 # Troubleshooting
-
 {: .no_toc }
 
 Issues concerning the primary operations of your Umbrel node.
@@ -17,13 +16,10 @@ If you see any discrepancies from the expected output, double check how you set 
 General questions and further learnings regarding the technology used in Umbrel can be found in the separate [General FAQ](faq.md).
 
 ## Table of contents
-
 {: .no_toc .text-delta }
 
 1. TOC
-   {:toc}
-
-## Common problems
+{:toc}
 
 ### Can I login using SSH?
 


### PR DESCRIPTION
Follow up to https://github.com/UmbrelInfo/UmbrelInfo.github.io/pull/2

Introduced new issue, noticed here: https://github.com/UmbrelInfo/UmbrelInfo.github.io/pull/2#issuecomment-753508613

This should hopefully fix the TOS no longer being displayed correctly at the top.

Sorry about this!